### PR TITLE
Merge da branch `feat/throttling_pagination` na branch `dev`

### DIFF
--- a/setup/settings.py
+++ b/setup/settings.py
@@ -137,6 +137,14 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '50/day',
+        'user': '10000/day'
+    }
 }
 
 SIMPLE_JWT = {

--- a/setup/settings.py
+++ b/setup/settings.py
@@ -144,7 +144,9 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '50/day',
         'user': '10000/day'
-    }
+    },
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 20,
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
Adicionado paginção na API, são retornados 20 elementos por página e está sendo usado a paginação por número de página.

Foi adicionado um throttling na API e usuários não autenticados podem realizar 50 request por dia, enquanto que usuários autenticados podem realizar 10000 requests por dia.